### PR TITLE
Problem: txt_files is used to define if you wish to consider specific…

### DIFF
--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -22,7 +22,7 @@ Prepare input files
 
 The input files are defined by text files (extension: ``.txt``) that
 hold non-zero rainfall timeseries. The data are split per station and
-per year with a specific datafile tag:
+per year with a specific datafile tag (format: **SOURCE\_STATION\_YEAR.txt**):
 
 -  KMI\_6414\_2004.txt
 -  KMI\_6414\_2005.txt
@@ -32,7 +32,7 @@ per year with a specific datafile tag:
 -  ...
 
 The content of each of this file is a **non-zero** rainfall timeseries
-(no header, space delimited, see for example **TO DO: LINK**):
+(no header, space delimited):
 
 ::
 
@@ -43,10 +43,11 @@ The content of each of this file is a **non-zero** rainfall timeseries
      ... ...
 
 with the first column being the timestamp from the start of the year
-(minutes) , and second the rainfall depth (in mm). An overview of the
-present datafiles for the analysis is saved in a ``files.csv`` file
-(example in **TO DO:LINK**). This file can be used to remove specific
-files from the analysis (column ``consider``):
+(minutes) , and second the rainfall depth (in mm). Optionally, if you wish
+to only consider a select number of input data files, you can define a
+``.csv``-file with following structure. If you do not do so, the code will
+generate one for you:
+
 
 +----------+-------------------+------------+
 | source   | datafile          | consider   |
@@ -64,7 +65,7 @@ Compute erosivity: EI30
 -----------------------
 
 The erosivity (EI30-values) can be computed by navigating to the
-**TO DO: LINK** folder (make sure to activating the rfactor environment,
+main folder (make sure to activating the rfactor environment,
 ``conda activate rfactor``). In Python, import:
 
 ::
@@ -81,8 +82,13 @@ And run code:
     compute_rfactor(rainfall_inputdata_folder,results_folder,"matlab")
 
 The current implementation makes use of a Matlab engine, which requires
-Matlab to be installed. Future versions of this package will use Python.
-Results are written to the *results\_folder*-folder.
+Matlab to be installed. Results are written to the *results\_folder*-folder.
+
+.. note::
+
+If you are using the free software Octave (see :ref:`installation <octave>`)
+and make sure you have the ``.env``-file with the reference to your octave
+installation in your current working directory!
 
 Analyse R-values
 ----------------
@@ -109,18 +115,31 @@ folder):
        fmap_rainfall = Path(r"./tests/data/test_rainfalldata")
        fmap_erosivty = = Path(r"results") # Folder path where results are written to (see above).
 
--  Define the path for the ``files.csv``-file:
+
+-  Create a erosivitydata object:
+
+   ::
+
+       erosivitydata = ErosivityData(fmap_rainfall, fmap_erosivity)
+
+-  (optional) Define the path for the ``files.csv``-file:
 
    ::
 
        txt_files = Path(r"./test/data/files.csv")
 
--  Create a erosivitydata object, build the data set with the
-   *files.csv* file and load the data:
+-  Build and load the data set:
 
-   ::
+    ::
 
-       erosivitydata = ErosivityData(fmap_rainfall, fmap_erosivity)
+       df_files = erosivitydata.build_data_set()
+       erosivitydata.load_data(df_files)
+
+- (optional) Alternative to building the data set with the code, you can use
+  a self-defined ``files.csv``-file:
+
+    ::
+
        df_files = erosivitydata.build_data_set(txt_files)
        erosivitydata.load_data(df_files)
 

--- a/docs/notebooks/analysis_flanders.ipynb
+++ b/docs/notebooks/analysis_flanders.ipynb
@@ -183,9 +183,18 @@
    "source": [
     "os.chdir(cwd)\n",
     "data = ErosivityData(fmap_rainfall,fmap_erosivity)\n",
-    "df_files = data.build_data_set(txt_files)\n",
+    "df_files = data.build_data_set()\n",
     "data.load_data(df_files)\n",
     "df_files.to_csv(\"overview_files_stations.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_files"
    ]
   },
   {
@@ -255,6 +264,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=[12,7.5])\n",
+    "years = range(1898,2020,1)\n",
     "df_R=data.load_R([\"KMI_6447\",\"KMI_FS3\"], years)\n",
     "df_R = df_R[~np.isnan(df_R[\"value\"])].sort_values(\"year\")\n",
     "plt.plot(df_R[\"year\"],df_R[\"value\"],label=\"KMI_FS3 (1898-2002)\")\n",
@@ -536,7 +546,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.4"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -3,7 +3,7 @@ import numpy as np
 from pathlib import Path
 from .conftest import erosivitydata, fmap_rainfall_one_file, fmap_erosivity_one_file
 from rfactor.rfactor import compute_rfactor
-from rfactor.process import load_erosivity_data
+from rfactor.process import load_erosivity_data,ErosivityData
 
 @pytest.mark.parametrize(
     "debug,engine",
@@ -106,3 +106,28 @@ def test_ukkel(lst_timeseries, rfactor):
     df_R = erosivitydata.load_R(["KMI_6447", "KMI_FS3"], lst_timeseries)
 
     np.testing.assert_allclose(np.mean(df_R["value"]), rfactor, atol=1e-2)
+
+@pytest.mark.parametrize(
+    "generate_df_files,number_of_files_to_consider",
+    [(True,872),
+     (False,554)
+    ],
+)
+def test_build_dataset(generate_df_files,number_of_files_to_consider):
+    """Test the building of the erosivity data set.
+
+    Parameters
+    ----------
+    generate_df_files: bool
+        Generate a df_files (holding references to files and whethet to consider
+        them or not) automatically (if False you need to generate one yourself).
+    number_of_files_to_consider: int
+        Expected number of to consider files.
+    """
+    from .conftest import fmap_rainfall,fmap_erosivity,txt_files
+    erosivitydata = ErosivityData(fmap_rainfall, fmap_erosivity)
+    if generate_df_files:
+        df_files = erosivitydata.build_data_set()
+    else:
+        df_files =  erosivitydata.build_data_set(txt_files)
+    assert number_of_files_to_consider==int(np.sum(df_files["consider"]))


### PR DESCRIPTION
… (station, year)-files. Yet in a number of cases you wish to autogenerate this file (in case you want to consider all files in a folder).

Solution: make txt_files optional, and automatically generate a dataframe with the same content (based on the file names).

See https://github.com/cn-ws/rfactor/issues/4

Merging and closing