### PR TITLE
Exclude uploading documentation on pull requests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,6 +46,10 @@ steps:
     when:
       branch:
         - master
+      event:
+         exclude:
+           - pull_request
+
 
 name: default
 


### PR DESCRIPTION
Upload would fail as the credentials are not available for PRs (and we don't want to publish PR's anyway).