### PR TITLE
Fix coverage report during testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ extras = True
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
 #          Comment those flags to avoid this py.test issue.
 addopts =
-    --cov example_project --cov-report term-missing
+    --cov rfactor --cov-report term-missing
     --verbose
 norecursedirs =
     dist


### PR DESCRIPTION
Current [coverage report in drone](https://cloud.drone.io/cn-ws/rfactor/121/1/3) was not properly configured. Thus PR fixes the reporting of the coverage as part of the CI.