### PR TITLE
remove tag from ``compute_erosivity``

### DIFF
--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -279,7 +279,7 @@ def compute_erosivity(rain, intensity_method=maximum_intensity):
 
     # couple tag
     all_erosivity = all_erosivity.merge(
-        rain[["station", "year", "tag"]].drop_duplicates(), on=["station", "year"]
+        rain[["station", "year"]].drop_duplicates(), on=["station", "year"]
     )
     all_erosivity.index = all_erosivity["datetime"]
 


### PR DESCRIPTION
the ``tag`` can be removed as it has no added value for the merging (it is merged on station and year, and tag is a composite of both columns)