### PR TITLE
Don't mark jupyter as a requirement

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - jupyter
   - numpy
   - matplotlib
   - pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ install_requires =
     matplotlib
     tqdm
 	python-dotenv
-    jupyter
     joblib
 
 [options.packages.find]
@@ -73,6 +72,7 @@ develop =
     sphinx
     sphinx_rtd_theme
     nbsphinx
+    jupyter
     pre-commit
     black
     flake8


### PR DESCRIPTION
I don't think jupyter should be a requirement for the r-factor
package.