### PR TITLE
WIP: Add function to enable resampling to 10 minutes

### DIFF
--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -223,3 +223,38 @@ For example, consider one wants to compute the R-value for 2017 and 2018, for Uk
 .. code-block:: python
     erosivity_selected = erosivity[(erosivity["year"].isin([2017, 2018])) &
                                    (erosivity["station"].isin(['KMI\_6447', 'KMI\_FS3']))]
+
+Resample input rainfall data
+----------------------------
+
+The current implementation of the R-factor are valid on a resolution of
+10-minutes. A resampling module allowing you to resample to a 10-minute
+resolution is provided in the package:
+
+.. code-block:: python
+
+    # import
+    import pandas as pd
+    from rfactor.process import resample_rainfall
+    #input
+    df = pd.DataFrame(columns=["datetime", "rain_mm"])
+    freq="15T"
+    df["datetime"] = pd.date_range("2018-01-01 03:30", periods=6, freq=freq)
+    df["rain_mm"] = [0, 0.08, 0, 0.21, 0.05, 0]
+    df.index = df["datetime"]
+    df.index.freq = freq
+
+    # standard resampling to 10 minutes is implemented
+    df_o = resample_rainfall(df)
+
+    # print
+    print(df_o)
+
+Resampling to other frequencies is also supported:
+
+.. code-block:: python
+
+    df_o = resample_rainfall(df,output_frequency="20T")
+
+    # print
+    print(df_o)

--- a/src/rfactor/process.py
+++ b/src/rfactor/process.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 from pandas import Timedelta
 from tqdm import tqdm
-from valid import valid_rainfall_timeseries
+
+from rfactor.valid import valid_rainfall_timeseries
 
 
 def _days_since_start_year(series):
@@ -338,7 +339,7 @@ def compute_rainfall_statistics(df_rainfall, df_station_metadata=None):
     return df_statistics
 
 
-@valid_rainfall_timeseries(req_col={"datetime", "rain_mm"}, req_freq=10)
+@valid_rainfall_timeseries(req_col={"datetime", "rain_mm"})
 def resample_rainfall(rain, output_frequency="10T"):
     """Resample rainfall dataset to 10 minutes resolution
 

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -5,8 +5,13 @@ import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 
+import rfactor.process
+
 TIME_BETWEEN_EVENTS = "6 hours"
 MIN_CUMUL_EVENT = 1.27
+
+
+
 
 
 class RFactorInputError(Exception):

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -5,13 +5,8 @@ import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 
-import rfactor.process
-
 TIME_BETWEEN_EVENTS = "6 hours"
 MIN_CUMUL_EVENT = 1.27
-
-
-
 
 
 class RFactorInputError(Exception):

--- a/src/rfactor/valid.py
+++ b/src/rfactor/valid.py
@@ -1,7 +1,5 @@
 from functools import wraps
 
-from process import resample_rainfall
-
 
 def valid_column(rain, req_col):
     """Input dataframe has valid required columns
@@ -26,7 +24,7 @@ def valid_const_freq(rain):
     rain: pandas.DataFrame
     """
     # constant frequency
-    if len(rain["datetime"].diff().unique()) > 1:
+    if len(rain["datetime"].diff().unique()) > 2:
         msg = (
             "Timeseries resolution is not a strict constant, please define "
             "rainfall timeseries with one temporal resolution."
@@ -68,7 +66,8 @@ def valid_freq(df_freq, req_freq=None):
         if df_freq.nanos != 1000000000 * 60 * req_freq:
             msg = (
                 f"Rainfall resolution should be equal to {req_freq} minutes, "
-                f"resample input rainfall with {resample_rainfall}"
+                f"resample input rainfall with the resample functionalities available"
+                f" in this package."
             )
             raise IOError(msg)
 

--- a/src/rfactor/valid.py
+++ b/src/rfactor/valid.py
@@ -1,0 +1,139 @@
+from functools import wraps
+
+from process import resample_rainfall
+
+
+def valid_column(rain, req_col):
+    """Input dataframe has valid required columns
+
+    Parameters
+    ----------
+    rain: pd.DataFrame
+        To test dataframe
+    req_col: set
+        Required columns in dataframe, e.g. {"datetime", "rain_mm"}
+    """
+    # test for columns
+    if not req_col.issubset(rain.columns):
+        raise KeyError(f"DataFrame should contain {req_col}  columns.")
+
+
+def valid_const_freq(rain):
+    """Check if rainfall inputdata has constant frequency
+
+    Parameters
+    ----------
+    rain: pandas.DataFrame
+    """
+    # constant frequency
+    if len(rain["datetime"].diff().unique()) > 1:
+        msg = (
+            "Timeseries resolution is not a strict constant, please define "
+            "rainfall timeseries with one temporal resolution."
+        )
+        raise IOError(msg)
+
+
+def valid_freq(df_freq, req_freq=None):
+    """Test for valid frequency of input data
+
+    The frequency of the input data is tested to a defined frequency. Limit
+    usage R-factor package to above 1-minute resolution.
+
+    Parameters
+    ----------
+    df_freq: pandas.DatetimeIndex.freq
+        Temporal frequency in the rainfall data
+    req_freq: int, default None
+        Required frequency (minutes). If None, the req_frequence should at least be
+        1 minute.
+    """
+    # test for frequency
+    if df_freq is None:
+        msg = "Please define a frequency for your input timeseries."
+        raise IOError(msg)
+
+    # if required frequency is zeros, test if the dataframe is at least a one minute
+    # resolution.
+    if req_freq is None:
+
+        if df_freq.nanos < 1000000000 * 60:
+            msg = (
+                "The R-factor package cannot process sub-minute rainfall input data, "
+                "resample to at least a one minute resolution."
+            )
+            raise IOError(msg)
+
+    else:
+        if df_freq.nanos != 1000000000 * 60 * req_freq:
+            msg = (
+                f"Rainfall resolution should be equal to {req_freq} minutes, "
+                f"resample input rainfall with {resample_rainfall}"
+            )
+            raise IOError(msg)
+
+
+def valid_rainfall_timeseries(
+    func=None, req_col={"datetime", "rain_mm"}, req_freq=None
+):
+    """Customisable decorator to check pandas input rainfall data for functions used in
+     this package.
+
+    Parameters
+    ----------
+    func: callable, default None
+    req_col: set
+        See :func:`rfactor.process.valid_column`
+    req_freq int
+        See :func:`rfactor.process.valid_freq`
+
+    Returns
+    -------
+    decorator: callable
+        Return the execution of the actual decorator
+
+    Notes
+    -----
+    Use super decorator to allow for decorator inputs
+    """
+    assert callable(func) or func is None
+
+    def _decorator(func):
+        """
+
+        Parameters
+        ----------
+        func: callable
+            Input function
+
+        Returns
+        -------
+        wrapper: callable
+            Wrapper function
+        """
+
+        @wraps(func)
+        def wrapper(rain, **kwargs):
+            """
+
+            Parameters
+            ----------
+            rain: pandas.DataFrame
+                Input rainfall dataseries
+            kwarg: dict
+                Keyword arguments
+
+            Returns
+            -------
+            func: callable
+                Return the execution of the function call
+            """
+            valid_column(rain, req_col)
+            freq = rain.index.freq
+            valid_freq(freq, req_freq)
+            valid_const_freq(rain)
+            return func(rain, **kwargs)
+
+        return wrapper
+
+    return _decorator(func) if callable(func) else _decorator

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -13,37 +13,46 @@ from rfactor.process import (
     get_rfactor_station_year,
     load_rain_file,
     load_rain_folder,
-    write_erosivity_data,
     resample_rainfall,
     valid_column,
+    valid_const_freq,
     valid_freq,
-    valid_const_freq
+    write_erosivity_data,
 )
+
 
 @pytest.mark.parametrize(
     "idx,values,freq,idx_n,values_n",
-    [(pd.date_range("2018-01-01 03:30", periods=4, freq="1H"),
-      [0.06,0.08,0.21,0.05],
-      "1H",
-     pd.date_range("2018-01-01 03:30", periods=19, freq="10T"),
-    [0.01]+[0.0133]*6+[0.035]*6+[0.0083]*6),
-     (pd.date_range("2018-01-01 03:30", periods=6, freq="15T"),
-      [0,0.08,0,0.21,0.05,0],
-      "15T",
-     pd.date_range("2018-01-01 03:30", periods=9, freq="10T"),
-      [0,0.026667*2,0.026667,0,0.14,0.0866667,0.016667*2,0,0]),
-    (pd.date_range("2018-01-01 03:30", periods=5, freq="15T"),
-      [0.08, 0, 0.21, 0.05, 0],
-      "15T",
-      pd.date_range("2018-01-01 03:30", periods=7, freq="10T"),
-      [0.026667 * 2, 0, 0.07, 0.14, 0.016667 * 2, 0.016667,0])])
+    [
+        (
+            pd.date_range("2018-01-01 03:30", periods=4, freq="1H"),
+            [0.06, 0.08, 0.21, 0.05],
+            "1H",
+            pd.date_range("2018-01-01 03:30", periods=19, freq="10T"),
+            [0.01] + [0.0133] * 6 + [0.035] * 6 + [0.0083] * 6,
+        ),
+        (
+            pd.date_range("2018-01-01 03:30", periods=6, freq="15T"),
+            [0, 0.08, 0, 0.21, 0.05, 0],
+            "15T",
+            pd.date_range("2018-01-01 03:30", periods=9, freq="10T"),
+            [0, 0.026667 * 2, 0.026667, 0, 0.14, 0.0866667, 0.016667 * 2, 0, 0],
+        ),
+        (
+            pd.date_range("2018-01-01 03:30", periods=5, freq="15T"),
+            [0.08, 0, 0.21, 0.05, 0],
+            "15T",
+            pd.date_range("2018-01-01 03:30", periods=7, freq="10T"),
+            [0.026667 * 2, 0, 0.07, 0.14, 0.016667 * 2, 0.016667, 0],
+        ),
+    ],
+)
+def test_resample_rainfall(idx, values, freq, idx_n, values_n):
 
-def test_resample_rainfall(idx,values,freq,idx_n,values_n):
-
-    df = pd.DataFrame(columns=["datetime","rain_mm"])
+    df = pd.DataFrame(columns=["datetime", "rain_mm"])
     df["datetime"] = idx
     df["rain_mm"] = values
-    df.index= df["datetime"]
+    df.index = df["datetime"]
     df.index.freq = freq
 
     df_o = resample_rainfall(df)
@@ -51,49 +60,50 @@ def test_resample_rainfall(idx,values,freq,idx_n,values_n):
     # test dates
     df = pd.DataFrame(columns=["rain_mm"])
     df["rain_mm"] = values_n
-    df.index= idx_n
-    df.index.name="datetime"
-    pd.testing.assert_frame_equal(df,df_o,atol=1e-3)
+    df.index = idx_n
+    df.index.name = "datetime"
+    pd.testing.assert_frame_equal(df, df_o, atol=1e-3)
+
 
 def test_valid_rainfall_timeseries():
-
+    """Test subfunctionalities of valid_rainfall_timeseries decorator"""
     idx = pd.date_range("2018-01-01 03:30", periods=2, freq="1S")
-    val = [0.06,0.08]
+    val = [0.06, 0.08]
 
-    df = pd.DataFrame(columns=["datetime","rain_mm"])
+    df = pd.DataFrame(columns=["datetime", "rain_mm"])
     df["datetime"] = idx
     df.index = df["datetime"]
     df["rain_mm"] = val
 
-
     with pytest.raises(KeyError) as excinfo:
-        valid_column(df,{"datetime","rain"})
+        valid_column(df, {"datetime", "rain"})
     assert "should contain" in str(excinfo.value)
 
     freq = df.index.freq
     with pytest.raises(IOError) as excinfo:
-        valid_freq(freq,mode_test_freq=1)
+        valid_freq(freq, mode_test_freq=1)
     assert "Please define a frequency for your input timeseries" in str(excinfo.value)
 
     df.index.freq = "1S"
     freq = df.index.freq
 
     with pytest.raises(IOError) as excinfo:
-        valid_freq(freq,mode_test_freq=1)
+        valid_freq(freq, mode_test_freq=1)
     assert "Rainfall resolution can not be subminute resolution" in str(excinfo.value)
 
     with pytest.raises(IOError) as excinfo:
-        valid_freq(freq,mode_test_freq=2)
+        valid_freq(freq, mode_test_freq=2)
     assert "Rainfall resolution should be equal to 10 minutes" in str(excinfo.value)
 
-    idx = pd.DatetimeIndex(["2018-01-01 03:30","2018-01-01 03:31","2018-01-01 03:33"])
-    val = [0.06,0.08,0.0]
-    df = pd.DataFrame(columns=["datetime","rain_mm"])
+    idx = pd.DatetimeIndex(["2018-01-01 03:30", "2018-01-01 03:31", "2018-01-01 03:33"])
+    val = [0.06, 0.08, 0.0]
+    df = pd.DataFrame(columns=["datetime", "rain_mm"])
     df["datetime"] = idx
     df["rain"] = val
     with pytest.raises(IOError) as excinfo:
         valid_const_freq(df)
     assert "Timeseries resolution is not a strict constant" in str(excinfo.value)
+
 
 def test_days_since_last_year_float():
     """Moment of the day is translated as decimal number."""
@@ -323,4 +333,3 @@ def test_rainfall_statistics_with_metadata(rain_data_folder, station_metadata):
     assert set(rf_stats.columns) == set(
         ["year", "station", "x", "y", "records", "min", "median", "max"]
     )
-

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -14,15 +14,12 @@ from rfactor.process import (
     load_rain_file,
     load_rain_folder,
     resample_rainfall,
-    valid_column,
-    valid_const_freq,
-    valid_freq,
     write_erosivity_data,
 )
 
 
 @pytest.mark.parametrize(
-    "idx,values,freq,idx_n,values_n",
+    "idx,values,freq,idx_n,values_n,freq_n",
     [
         (
             pd.date_range("2018-01-01 03:30", periods=4, freq="1H"),
@@ -30,6 +27,7 @@ from rfactor.process import (
             "1H",
             pd.date_range("2018-01-01 03:30", periods=19, freq="10T"),
             [0.01] + [0.0133] * 6 + [0.035] * 6 + [0.0083] * 6,
+            "10T",
         ),
         (
             pd.date_range("2018-01-01 03:30", periods=6, freq="15T"),
@@ -37,6 +35,15 @@ from rfactor.process import (
             "15T",
             pd.date_range("2018-01-01 03:30", periods=9, freq="10T"),
             [0, 0.026667 * 2, 0.026667, 0, 0.14, 0.0866667, 0.016667 * 2, 0, 0],
+            "10T",
+        ),
+        (
+            pd.date_range("2018-01-01 03:30", periods=6, freq="15T"),
+            [0, 0.08, 0, 0.21, 0.05, 0],
+            "15T",
+            pd.date_range("2018-01-01 03:40", periods=5, freq="20T"),
+            [0.026667 * 2, 0.026667, 0.14 + 0.0866667, 0.016667 * 2, 0],
+            "20T",
         ),
         (
             pd.date_range("2018-01-01 03:30", periods=5, freq="15T"),
@@ -44,10 +51,11 @@ from rfactor.process import (
             "15T",
             pd.date_range("2018-01-01 03:30", periods=7, freq="10T"),
             [0.026667 * 2, 0, 0.07, 0.14, 0.016667 * 2, 0.016667, 0],
+            "10T",
         ),
     ],
 )
-def test_resample_rainfall(idx, values, freq, idx_n, values_n):
+def test_resample_rainfall(idx, values, freq, idx_n, values_n, freq_n):
 
     df = pd.DataFrame(columns=["datetime", "rain_mm"])
     df["datetime"] = idx
@@ -55,7 +63,7 @@ def test_resample_rainfall(idx, values, freq, idx_n, values_n):
     df.index = df["datetime"]
     df.index.freq = freq
 
-    df_o = resample_rainfall(df)
+    df_o = resample_rainfall(df, output_frequency=freq_n)
 
     # test dates
     df = pd.DataFrame(columns=["rain_mm"])
@@ -63,46 +71,6 @@ def test_resample_rainfall(idx, values, freq, idx_n, values_n):
     df.index = idx_n
     df.index.name = "datetime"
     pd.testing.assert_frame_equal(df, df_o, atol=1e-3)
-
-
-def test_valid_rainfall_timeseries():
-    """Test subfunctionalities of valid_rainfall_timeseries decorator"""
-    idx = pd.date_range("2018-01-01 03:30", periods=2, freq="1S")
-    val = [0.06, 0.08]
-
-    df = pd.DataFrame(columns=["datetime", "rain_mm"])
-    df["datetime"] = idx
-    df.index = df["datetime"]
-    df["rain_mm"] = val
-
-    with pytest.raises(KeyError) as excinfo:
-        valid_column(df, {"datetime", "rain"})
-    assert "should contain" in str(excinfo.value)
-
-    freq = df.index.freq
-    with pytest.raises(IOError) as excinfo:
-        valid_freq(freq, mode_test_freq=1)
-    assert "Please define a frequency for your input timeseries" in str(excinfo.value)
-
-    df.index.freq = "1S"
-    freq = df.index.freq
-
-    with pytest.raises(IOError) as excinfo:
-        valid_freq(freq, mode_test_freq=1)
-    assert "Rainfall resolution can not be subminute resolution" in str(excinfo.value)
-
-    with pytest.raises(IOError) as excinfo:
-        valid_freq(freq, mode_test_freq=2)
-    assert "Rainfall resolution should be equal to 10 minutes" in str(excinfo.value)
-
-    idx = pd.DatetimeIndex(["2018-01-01 03:30", "2018-01-01 03:31", "2018-01-01 03:33"])
-    val = [0.06, 0.08, 0.0]
-    df = pd.DataFrame(columns=["datetime", "rain_mm"])
-    df["datetime"] = idx
-    df["rain"] = val
-    with pytest.raises(IOError) as excinfo:
-        valid_const_freq(df)
-    assert "Timeseries resolution is not a strict constant" in str(excinfo.value)
 
 
 def test_days_since_last_year_float():

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import pytest
+
+from rfactor.valid import valid_column, valid_const_freq, valid_freq
+
+
+def test_valid_rainfall_timeseries():
+    """Test subfunctionalities of valid_rainfall_timeseries decorator"""
+    idx = pd.date_range("2018-01-01 03:30", periods=2, freq="1S")
+    val = [0.06, 0.08]
+
+    df = pd.DataFrame(columns=["datetime", "rain_mm"])
+    df["datetime"] = idx
+    df.index = df["datetime"]
+    df["rain_mm"] = val
+
+    with pytest.raises(KeyError) as excinfo:
+        valid_column(df, {"datetime", "rain"})
+    assert "should contain" in str(excinfo.value)
+
+    freq = df.index.freq
+    with pytest.raises(IOError) as excinfo:
+        valid_freq(freq)
+    assert "Please define a frequency for your input timeseries" in str(excinfo.value)
+
+    df.index.freq = "1S"
+    freq = df.index.freq
+
+    with pytest.raises(IOError) as excinfo:
+        valid_freq(freq)
+    assert "The R-factor package cannot process sub-minute " in str(excinfo.value)
+
+    with pytest.raises(IOError) as excinfo:
+        valid_freq(freq, req_freq=10)
+    assert "Rainfall resolution should be equal to 10 minutes" in str(excinfo.value)
+
+    idx = pd.DatetimeIndex(["2018-01-01 03:30", "2018-01-01 03:31", "2018-01-01 03:33"])
+    val = [0.06, 0.08, 0.0]
+    df = pd.DataFrame(columns=["datetime", "rain_mm"])
+    df["datetime"] = idx
+    df["rain"] = val
+    with pytest.raises(IOError) as excinfo:
+        valid_const_freq(df)
+    assert "Timeseries resolution is not a strict constant" in str(excinfo.value)


### PR DESCRIPTION
The input data for computing the R-factor should be equal to 10 minutes as this is the resolution on which the formula's are based. A resampling methodology for timeseries with another resolution is added. This can be used by users to resample. The workflow is as follows:

- The input rainfall data should always have a 10-minute resolution as formula's are developed on that scale.
- Run rfactor, and if input data are not 10 minute resolution, throw warning (or error), and suggest resampling function TO DO
- Apply resample: first resample to 1 minute (with bfill) and then resample to 10 minutes (sum), do not allow non-constant frequencies and do not allow sub-minute frequencies.
- Rerun rfactor with resampled data


To do:

- [x] Check docs
- [x] Check application decorator
- [x] Check precommit
- [x] Validate decorator
- [ ] Add tutorial to tutorial page