### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^docs/conf.py'
 
 repos:
-- repo: git://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1
   hooks:
   - id: trailing-whitespace


### PR DESCRIPTION
Solution: adjust pre-commit repo reference (see https://github.com/cn-ws/rfactor/pull/54#issuecomment-1109467203)
Problem: the precommit in the drone failed due to a  "The unauthenticated git protocol on port 9418 is no longer supported."