### PR TITLE
WIP: changes in maximum intensity

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python
+  - python=3.8
   - numpy
   - matplotlib
   - pandas

--- a/src/rfactor/__init__.py
+++ b/src/rfactor/__init__.py
@@ -4,6 +4,8 @@ from rfactor.rfactor import (
     compute_erosivity,
     maximum_intensity,
     maximum_intensity_matlab_clone,
+    maximum_intensity_matlab_clone_fix
+    
 )
 
 if sys.version_info[:2] >= (3, 8):

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -110,7 +110,7 @@ def maximum_intensity_matlab_clone(df):
     maxprecip_30min = 0.0
 
     if timestamps[-1] - timestamps[0] <= 30:
-        maxprecip_30min = rain[0] * 2  # *2 to mimick matlab
+        maxprecip_30min = rain[0]   # *2 to mimick matlab
 
     for idx in range(len(df) - 1):
         eind_30min = timestamps[idx] + 20

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -109,10 +109,10 @@ def maximum_intensity_matlab_clone(df):
 
     maxprecip_30min = 0.0
 
-    if timestamps[-1] - timestamps[0] <= 30:
+    if timestamps[-1] - timestamps[0] < 30:     #timestamps contain rain from previous 10min, so the difference in timestamp != to accounted mins
         maxprecip_30min = np.sum(rain)   # *2 to mimick matlab
 
-    for idx in range(len(df) - 1):
+    for idx in range(len(df)):
         eind_30min = timestamps[idx] + 20
         begin_rain = np.round(rain_cum[idx] - rain[idx],2)                    #handeling errors due to unstable digits
 

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -69,22 +69,17 @@ def rain_energy_per_unit_depth(rain):
     rain_energy = 0.1112 * ((rain * 6.0) ** 0.31) * rain
     return rain_energy.sum()
 
-
 def maximum_intensity_matlab_clone(df):
     """Maximum rain intensity for 30-min interval (Matlab clone).
-
     The implementation is a direct Python-translation of the original Matlab
     implementation by Verstraeten.
-
     Parameters
     ----------
     df : pandas.DataFrame
         DataFrame with rainfall time series. Needs to contain the following columns:
-
         - *datetime* (pandas.Timestamp): Time stamp
         - *rain_mm* (float): Rain in mm
         - *event_rain_cum* (float): Cumulative rain in mm
-
     Returns
     -------
     maxprecip_30min : float
@@ -109,15 +104,15 @@ def maximum_intensity_matlab_clone(df):
 
     maxprecip_30min = 0.0
 
-    if timestamps[-1] - timestamps[0] < 30:     #timestamps contain rain from previous 10min, so the difference in timestamp != to accounted mins
-        maxprecip_30min = np.sum(rain)   # *2 to mimick matlab
+    if timestamps[-1] - timestamps[0] <= 30:
+        maxprecip_30min = np.sum(rain)
 
     for idx in range(len(df)):
         eind_30min = timestamps[idx] + 20
-        begin_rain = np.round(rain_cum[idx] - rain[idx],2)                    #handeling errors due to unstable digits
+        begin_rain = rain_cum[idx] - rain[idx]
 
-        eind_rain = np.round(np.interp(eind_30min, timestamps, rain_cum),2)   #handeling errors due to unstable digits
-        precip_30min = np.round(eind_rain - begin_rain,2)                     #handeling errors due to unstable digits
+        eind_rain = np.interp(eind_30min, timestamps, rain_cum)
+        precip_30min = eind_rain - begin_rain
 
         if precip_30min > maxprecip_30min:
             maxprecip_30min = precip_30min

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -114,10 +114,10 @@ def maximum_intensity_matlab_clone(df):
 
     for idx in range(len(df) - 1):
         eind_30min = timestamps[idx] + 20
-        begin_rain = rain_cum[idx] - rain[idx]
+        begin_rain = np.round(rain_cum[idx] - rain[idx])                    #handeling errors due to unstable digits
 
-        eind_rain = np.interp(eind_30min, timestamps, rain_cum)
-        precip_30min = eind_rain - begin_rain
+        eind_rain = np.round(np.interp(eind_30min, timestamps, rain_cum))   #handeling errors due to unstable digits
+        precip_30min = np.round(eind_rain - begin_rain)                     #handeling errors due to unstable digits
 
         if precip_30min > maxprecip_30min:
             maxprecip_30min = precip_30min

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -145,7 +145,7 @@ def maximum_intensity(df):
         Maximal 30-minute intensity during event (in mm/h).
     """
     # formula requires mm/hr, intensity is derived on half an hour
-    return df.rolling("30min", on="datetime")["rain_mm"].sum().max() * 2
+    return np.round(df.rolling("30min", on="datetime")["rain_mm"].sum().max() * 2,2)
 
 
 def _compute_erosivity(

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -114,10 +114,10 @@ def maximum_intensity_matlab_clone(df):
 
     for idx in range(len(df) - 1):
         eind_30min = timestamps[idx] + 20
-        begin_rain = np.round(rain_cum[idx] - rain[idx])                    #handeling errors due to unstable digits
+        begin_rain = np.round(rain_cum[idx] - rain[idx],2)                    #handeling errors due to unstable digits
 
-        eind_rain = np.round(np.interp(eind_30min, timestamps, rain_cum))   #handeling errors due to unstable digits
-        precip_30min = np.round(eind_rain - begin_rain)                     #handeling errors due to unstable digits
+        eind_rain = np.round(np.interp(eind_30min, timestamps, rain_cum),2)   #handeling errors due to unstable digits
+        precip_30min = np.round(eind_rain - begin_rain,2)                     #handeling errors due to unstable digits
 
         if precip_30min > maxprecip_30min:
             maxprecip_30min = precip_30min

--- a/src/rfactor/rfactor.py
+++ b/src/rfactor/rfactor.py
@@ -110,7 +110,7 @@ def maximum_intensity_matlab_clone(df):
     maxprecip_30min = 0.0
 
     if timestamps[-1] - timestamps[0] <= 30:
-        maxprecip_30min = rain[0]   # *2 to mimick matlab
+        maxprecip_30min = np.sum(rain)   # *2 to mimick matlab
 
     for idx in range(len(df) - 1):
         eind_30min = timestamps[idx] + 20


### PR DESCRIPTION
##  Differences Handling ‘unknown Values’ in Maximum_intesity

The difference between the two different Maximum_intensity functions (Maximum_Intensity_Matlab_Clone and Maximum_Intensity (FLUVES)) mostly lies in the difference of how the handle ‘unknown values. ‘Unknown Values’, here meaning: values which where potentially lost due the format of the data set, namely a non-zero time series, occur when in the original dataset has a NAN-value for a particular timestep or if the measured rain was 0.00 mm in a particular timestep. This removal of timesteps, creates an uncertainty about what happened in removed timesteps, since we are unable to know if a removed value was NAN or a 0.00mm measurement. In the two methods, distinct assumptions are made, leading to a divergent result in the maximum intensity (and therefore in the R-Factor, as well). The Matlab_Clone function assumes that ‘unknown values’ are erratic values and thus interpolates between the closest measured rain values in order to get a rain value for that timestep. The FLUVES method, on the other hand, assumes that all ‘unknown values’ are 0.00mm values, and uses this in the calculations of the maximum intensity.

Although this is the common distinction between the two methods, this interpolation does not cause the biggest difference between the two calculated maximum intensities. The Matlab_Clone function has some particularities, which lead to different values, and could be problematic, especially for high rain intensities in short periods of time. When the duration of a rainfall event is shorter than 30 min, a special condition has been implemented in the Matlab_clone code, namely only the rainfall of the first timestep is considered in order to calculate the maximum intensity for the rainfall event. There are 2 errors in the code of this condition, however. Firstly, the time interval is wrongly defined: (`timestamps[-1] - timestamps[0] <= 30`, should be: `< 30`, since a timestep contains 10 min i.e. timestep 10 to 40 contain 40 minutes of rainfall data, however it would be considered by the criterium). Secondly, there is a `*2` too many in the formula, this causes extreme events to be overexaggerated, which leads to the biggest differences in both methods. The implementation of this `*2` is probably taken from Wischmeier & Smith (1978) which suggest that for the rain intensity for events with a shorther duration than 30min, the rainfall depth should be multiplied by 2. The coding implementation here leads to a multiplication by 4, so the first *2 can be deleted. The initial implementation also only considers the rainfall of the first 10min interval, which should thus be changed to the sum of all the rainfall in the rain event shorter than 30 min (therefor: `np.sum(rain)`).

In addition, in the for-loop of the Matlab_clone function, the iteration is only done up to the penultimate measurement (`for idx in range(len(df)-1)`). This leads to the omission of the last measurement, which is problematic when this value is the highest value of rainfall event and a hiatus occurs just before this measurement. This is the case, because this high value would only be considered in the interpolation of the penultimate timestep, but not for the final timestep itself, which could still be the highest intensity, especially if the last measurement value is high. This then leads to an underestimation of the maximum intensity of the particular rainfall event. The error could be, at least to my knowledge, be due to the translation from MatLab to Python code, since the indexing is different in both languages (1 and 0, resp.) This could, however, also have been included purposely, but why I do not see clearly. Does anyone know more about this?

I added the changes to the GIT-code and added an explicit rounding (to eliminate rounding differences in both methods). All mentioned changes have reduced the difference between both methods in maximum error per rainfall event from 70.02 to 6.36, the minimum error per rainfall event (highest negative error) form -33.34 to 0.00 and the total absolute error from 4808.09 to 646.08 for all rainfall events up to 2021. 

The final difference (646.08) can than be considered as the real difference between both methods (namely the interpolation over unknown values in rain event in the Matlab_Clone). If these changes seem reasonable to you, the Matlab_Clone should be implemented as this. It would maybe be interesting to implement these changes in a new function and keeping Matlab_Clone unchanged, I however have not been able to manipulate the script in such manner. 
